### PR TITLE
Fix server crash when a player sends an empty command

### DIFF
--- a/server/server_core/commands.rs
+++ b/server/server_core/commands.rs
@@ -89,6 +89,10 @@ impl CommandManager {
     pub fn execute_command(&self, command: &str, mod_manager: &mut ModManager, executor: Option<EntityId>) -> Result<String> {
         // split the command into Vec<String>
         let mut arguments = command.split_whitespace().map(std::borrow::ToOwned::to_owned).collect::<Vec<_>>();
+        // a command that is empty or only whitespace has no name to look up
+        if arguments.is_empty() {
+            bail!("No command provided.")
+        }
         let command_name = arguments.remove(0);
         let function_name = format!("command_{command_name}");
 

--- a/server/server_core/mod.rs
+++ b/server/server_core/mod.rs
@@ -9,5 +9,6 @@ mod items;
 mod mod_manager;
 mod networking;
 mod players;
+mod tests;
 mod walls;
 mod world_generator;

--- a/server/server_core/tests.rs
+++ b/server/server_core/tests.rs
@@ -1,0 +1,49 @@
+#![allow(clippy::unwrap_used)]
+#![cfg(test)]
+mod tests {
+    use crate::server::server_core::commands::CommandManager;
+    use crate::shared::mod_manager::ModManager;
+
+    /// Runs a command against a `CommandManager` that has no mods loaded.
+    fn execute(command: &str) -> anyhow::Result<String> {
+        let commands = CommandManager::new();
+        let mut mods = ModManager::new(Vec::new());
+        commands.execute_command(command, &mut mods, None)
+    }
+
+    /// A chat message of just "/" is stripped to an empty string before it reaches
+    /// `execute_command`. That used to panic on `Vec::remove(0)`, which took the whole
+    /// server down and was reachable by any connected player from the stock client.
+    #[test]
+    fn test_empty_command_does_not_panic() {
+        assert!(execute("").is_err());
+    }
+
+    /// Same path, but the message was "/ " or similar: `split_whitespace` still yields
+    /// no tokens.
+    #[test]
+    fn test_whitespace_only_command_does_not_panic() {
+        assert!(execute("   ").is_err());
+        assert!(execute("\t").is_err());
+    }
+
+    /// An unknown command is reported back to the caller rather than being an error.
+    #[test]
+    fn test_unknown_command_is_reported() {
+        let result = execute("definitely_not_a_command").unwrap();
+        assert!(result.contains("definitely_not_a_command"), "unexpected output: {result}");
+    }
+
+    /// The builtin help command works without any mods loaded.
+    #[test]
+    fn test_help_command() {
+        let result = execute("help").unwrap();
+        assert!(result.contains("/help"), "unexpected output: {result}");
+    }
+
+    /// Help rejects more than one argument instead of panicking or silently ignoring.
+    #[test]
+    fn test_help_with_too_many_arguments() {
+        assert!(execute("help one two").is_err());
+    }
+}


### PR DESCRIPTION
## The bug

`CommandManager::execute_command` does this:

```rust
let mut arguments = command.split_whitespace().map(...).collect::<Vec<_>>();
let command_name = arguments.remove(0);   // panics when there are no tokens
```

For an empty or whitespace-only command, `split_whitespace()` yields nothing and `Vec::remove(0)` panics:

```
removal index (is 0) should be < len (is 0)
```

That takes down the entire server.

## Why it matters

**Any connected player can trigger this from an unmodified client.** The chat box's only guard is `!text.is_empty()` (`client/game/chat.rs:132`), and `"/"` is not empty — so it passes, `on_event` strips the leading slash to `""`, and `execute_command("")` panics.

The server GUI console reaches the same code via `handle_events`, and doesn't strip a slash at all, so a blank console line does it too.

Worth noting this is exactly the class of bug the ~150 crate-wide clippy lints in `main.rs` are meant to catch — `clippy::panic` and `clippy::indexing_slicing` are both enabled, but neither sees through `Vec::remove`.

## The fix

Return an error instead of panicking. Both existing callers already handle `Err`: the chat path formats it back to the player as `Error: ...`, the console path prints it as a warning. No behaviour change for any valid command.

## Tests

New `server/server_core/tests.rs` following the existing `tests.rs` convention, covering the two panic cases plus unknown-command and help behaviour to pin down the surrounding contract.

Verified the regression tests are real — with the guard removed, both panic tests fail:

```
test server::server_core::tests::tests::test_empty_command_does_not_panic ... FAILED
test server::server_core::tests::tests::test_whitespace_only_command_does_not_panic ... FAILED
thread '...' panicked at server/server_core/commands.rs:92:38
```

With the fix: **27 passed; 0 failed** (22 existing + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)