### PR TITLE
Stop the server networking thread from panicking on client input

### DIFF
--- a/server/server_core/networking.rs
+++ b/server/server_core/networking.rs
@@ -91,8 +91,6 @@ impl ServerNetworking {
         );
     }
 
-    #[allow(clippy::expect_used)]
-    #[allow(clippy::unwrap_in_result)]
     fn net_receive_loop(event_sender: &Sender<Event>, packet_receiver: &Receiver<(Vec<u8>, Connection)>, is_running: &Arc<AtomicBool>, server_port: u16) -> Result<()> {
         let (handler, listener) = node::split::<()>();
 
@@ -117,7 +115,15 @@ impl ServerNetworking {
                     }
                 }
                 NetEvent::Message(peer, packet) => {
-                    let packet: Packet = bincode::deserialize(packet).expect("Failed to deserialize");
+                    // a malformed frame from one client must not take down networking for
+                    // everyone, so drop the packet and keep serving the other connections
+                    let packet: Packet = match bincode::deserialize(packet) {
+                        Ok(packet) => packet,
+                        Err(e) => {
+                            print_to_console(&format!("[{peer}] sent a packet that could not be deserialized, ignoring it: {e}"), 1);
+                            return;
+                        }
+                    };
                     if let Some(packet) = packet.try_deserialize::<NamePacket>() {
                         print_to_console(&format!("[{:?}] joined the game", packet.name), 0);
                         match event_sender.send(Event::new(NewConnectionEvent {
@@ -148,7 +154,11 @@ impl ServerNetworking {
                 }
 
                 while let Ok((packet_data, conn)) = packet_receiver.try_recv() {
-                    Self::send_packet_internal(&handler, &packet_data, &conn).expect("Failed to send Packet");
+                    // sending routinely fails when the peer has gone away between queueing
+                    // and sending, which is normal and must not kill the networking thread
+                    if let Err(e) = Self::send_packet_internal(&handler, &packet_data, &conn) {
+                        print_to_console(&format!("Failed to send a packet to [{}]: {e}", conn.address), 1);
+                    }
                 }
 
                 handler.signals().send_with_timer((), std::time::Duration::from_millis(1));


### PR DESCRIPTION
## The problem

Two `expect` calls sit on the server's network thread and turn recoverable, per-connection problems into a dead networking thread for **everyone**:

```rust
// server/server_core/networking.rs
let packet: Packet = bincode::deserialize(packet).expect("Failed to deserialize");
...
Self::send_packet_internal(&handler, &packet_data, &conn).expect("Failed to send Packet");
```

**The first**: any client that sends a malformed frame takes networking down for every other player.

**The second is worse, because it fires during normal operation.** `message-io` returns `SendStatus::ResourceNotFound` when the peer has gone away, and `send_packet_internal` turns that into an `Err`:

```rust
SendStatus::ResourceNotFound => bail!("Resource not found"),
```

So a client disconnecting in the window between a packet being queued and being sent kills the thread. That's an ordinary race, not an exotic one. (This is from reading the code path — I did not reproduce the race directly.)

## The change

Both sites now log and carry on, which is **what the client side already does** — `client/game/networking.rs` funnels errors into a shared `receive_loop_error` string that the main loop checks, rather than unwinding on the network thread. This brings the server in line.

- A bad packet is dropped with a warning naming the peer; that peer keeps its connection.
- A failed send is reported with the address and the loop continues to the next queued packet.

Also removes the now-dead `#[allow(clippy::expect_used)]` and `#[allow(clippy::unwrap_in_result)]` from `net_receive_loop`, so those lints keep their meaning there. The remaining `unwrap` in `init()` is the thread-spawn one, which keeps its own `allow` and comment.

## Verification

- `cargo test`: 22/22 pass.
- `cargo clippy`: **107 warnings, unchanged from baseline** — no new lint debt, and the two removed `allow`s didn't uncover anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)