### PR TITLE
Add clippy, rustfmt and a release build to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,10 @@ name: Rust
 
 on:
    push:
-     branches: [ "master" ]
+     branches: [ "master", "beta-5" ]
+   # no branch filter: a pull request against any branch gets checked, not just master
    pull_request:
-     branches: [ "master" ]
+   workflow_dispatch:
 
 env:
    CARGO_TERM_COLOR: always
@@ -15,11 +16,20 @@ jobs:
      runs-on: ubuntu-latest
 
      steps:
-     - uses: actions/checkout@v3
-     - run: rustup toolchain install stable --profile minimal
+     - uses: actions/checkout@v4
+     - run: rustup toolchain install stable --profile minimal --component clippy,rustfmt
      - name: Rust Cache
-       uses: Swatinem/rust-cache@v2.5.0
+       uses: Swatinem/rust-cache@v2
      - name: Install dependencies
-       run: sudo apt-get install -y libsdl2-dev
+       run: sudo apt-get update && sudo apt-get install -y libsdl2-dev
+     - name: Check formatting
+       run: cargo fmt --check
+     # main.rs sets #![deny(clippy::all)], so this already fails the build on any
+     # deny-level regression. It does not yet use -D warnings, because the tree has
+     # ~107 outstanding warnings; once those are cleared, add -D warnings here.
+     - name: Clippy
+       run: cargo clippy --all-targets
      - name: Run tests
        run: cargo test --verbose
+     - name: Release build
+       run: cargo build --release

--- a/shared/walls/breaking.rs
+++ b/shared/walls/breaking.rs
@@ -54,7 +54,6 @@ impl Walls {
             }
         }
 
-
         if let Some(breaking_wall) = breaking_wall {
             breaking_wall.is_breaking = true;
         } else {


### PR DESCRIPTION
## What CI does today

```yaml
- name: Run tests
  run: cargo test --verbose
```

That's it. Three gaps:

1. **Clippy never runs** — even though the ~150 hand-curated lints at the top of `main.rs` are the project's main quality mechanism. Nothing enforces them.
2. **rustfmt never runs**, despite a committed `rustfmt.toml`.
3. **Only the debug build is exercised**, so a release-only break could ship.

(Correcting something I'd assumed earlier: PRs targeting master *do* already get CI — `pull_request: branches: [master]` filters on the base branch. The trigger gap is narrower than "nothing runs off master".)

## Changes

| | |
|---|---|
| `cargo fmt --check` | new, blocking |
| `cargo clippy --all-targets` | new, blocking |
| `cargo build --release` | new, blocking |
| `pull_request` trigger | branch filter removed — PRs against *any* base get checked |
| `push` trigger | `master` + `beta-5` |
| `workflow_dispatch` | added, for manual runs |
| `actions/checkout` | v3 → v4 |
| `Swatinem/rust-cache` | 2.5.0 → v2 |
| `apt-get update` | added before install, needed for reliable `apt-get install` on the runner |

## On the clippy step

It deliberately **does not** use `-D warnings` yet. The tree has 107 outstanding warnings, so that flag would just make CI red on arrival.

It's still worth having as-is: `main.rs` sets `#![deny(clippy::all)]`, so any deny-level regression already fails the build. A comment in the workflow records that `-D warnings` should be added once the backlog is cleared — clippy says 82 of the 107 are auto-fixable via `cargo clippy --fix`, so that's a tractable follow-up.

## One code change

`shared/walls/breaking.rs` is reformatted — a single stray blank line, and the only thing in the tree `cargo fmt --check` flags. Without it the new fmt step would fail immediately.

## Verification

All four steps run locally against this branch:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — **exit 0** (107 warnings, no deny-level errors)
- `cargo test` — 22/22
- `cargo build --release` — succeeds

YAML parses and resolves to the intended triggers and step list.

## Not included

A macOS/Windows matrix. All three platforms have `Cargo.toml` sections and `#[cfg]` branches, so it would be valuable — but SDL2 setup on those runners is fiddly and I'd rather not add a job I haven't seen go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)