### PR TITLE
Save the world when a headless server is asked to shut down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "arboard",
  "bincode",
  "chrono",
+ "ctrlc",
  "darklua",
  "directories",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ arboard = { version = "3.3", default-features = false }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 noise = { version = "0.9", default-features = false }
 fnv = { version = "1.0", default-features = false }
+ctrlc = { version = "3.5", default-features = false, features = ["termination"] }
 hecs = { version = "0.10", default-features = false, features = ["std"] }
 message-io = { version = "0.19", default-features = false, features = ["tcp"] }
 kvptree = { version = "0.1", default-features = false }

--- a/main.rs
+++ b/main.rs
@@ -238,6 +238,17 @@ fn server_main(args: &[String]) {
 
     let server_running = Arc::new(AtomicBool::new(true));
 
+    // Without this, a headless server has no way to be stopped from outside the process:
+    // nothing else ever clears `server_running`, so Ctrl-C or SIGTERM kills the process
+    // before `Server::stop` runs and the world is never saved.
+    let running_on_signal = server_running.clone();
+    if let Err(error) = ctrlc::set_handler(move || {
+        println!("Shutdown requested, stopping the server and saving the world...");
+        running_on_signal.store(false, std::sync::atomic::Ordering::Relaxed);
+    }) {
+        println!("Failed to install the shutdown handler, the server will not save on Ctrl-C: {error}");
+    }
+
     let loading_text = Arc::new(Mutex::new("Loading".to_owned()));
 
     let curr_dir = std::env::current_dir();


### PR DESCRIPTION
## The bug

**A headless server has no shutdown path at all, so every shutdown loses the world.**

`Server::run` only leaves its loop when `is_running` goes false or a mod sets the state to `Stopping`:

```rust
if !is_running.load(Ordering::Relaxed) || self.get_state() == ServerState::Stopping {
    break;
}
...
self.stop(status_text, world_path)?;   // <- this is what calls save_world
```

In `nogui` mode nothing ever does either. `server_running` is cleared in exactly one place — `UiManager::should_ui_stop`, when the **GUI window** is closed. And there is no signal handling anywhere in the tree (`grep` for `ctrlc|signal_hook|SIGINT|SIGTERM|set_handler` returns nothing).

So Ctrl-C or SIGTERM kills the process outright, `Server::stop` never runs, `save_world` is never called, and all progress since startup is gone.

## The fix

Install a `ctrlc` handler that clears `server_running`, letting the existing loop exit normally and reach the existing save path. No changes to the shutdown logic itself — it was already correct, just unreachable.

The `termination` feature is enabled so **SIGTERM and SIGHUP** are handled too, which is what actually matters under systemd or `docker stop`. The handler is installed on the GUI path as well, so Ctrl-C on a windowed server also saves.

Adds one dependency: `ctrlc 3.5` (small, cross-platform — relevant since this project ships Windows builds).

## Verification

Before and after on the same machine, same command (`terralistic server nogui`), same `SIGTERM`:

**master:**
```
[INFO] server started in 2218ms
<SIGTERM>
process exits immediately — no "saving world" line
server_data/ never created — world lost
```

**this branch:**
```
[INFO] server started in 32148ms
<SIGTERM>
Shutdown requested, stopping the server and saving the world...
[INFO] [server mod] base_game mod stopped.
[INFO] saving world
[INFO] stopping server
[INFO] server stopped.

server_data/server.world   1113724 bytes
```

`cargo test` passes 22/22.

## Note

A second Ctrl-C during the save won't force-quit, since the handler replaces the default action and saving takes about a second. If you'd prefer a second signal to hard-exit, that's easy to add — I left it out because `clippy::exit` is enabled crate-wide and the simple version matches the existing architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)