### PR TITLE
Fix ChunkTracker sentinel collision and light chunk count arithmetic

### DIFF
--- a/client/game/chunk_tracker.rs
+++ b/client/game/chunk_tracker.rs
@@ -5,7 +5,10 @@ use std::collections::BTreeSet;
 /// allows you to get the earliest modified chunk
 /// used to delete unused chunks to save memory
 pub struct ChunkTracker {
-    modified_time: Vec<u32>,
+    /// Time each chunk was last touched, or `None` if it is not currently tracked.
+    /// This has to be an `Option` rather than a `0` sentinel, because `0` is a
+    /// legitimate elapsed time for the whole first second the tracker is alive.
+    modified_time: Vec<Option<u32>>,
     timer: std::time::Instant,
     queue: BTreeSet<(u32, usize)>,
 }
@@ -13,22 +16,22 @@ pub struct ChunkTracker {
 impl ChunkTracker {
     pub fn new(size: usize) -> Self {
         Self {
-            modified_time: vec![0; size],
+            modified_time: vec![None; size],
             timer: std::time::Instant::now(),
             queue: BTreeSet::new(),
         }
     }
 
-    fn get_modified_time(&mut self, chunk: usize) -> Result<&mut u32> {
+    fn get_modified_time(&mut self, chunk: usize) -> Result<&mut Option<u32>> {
         self.modified_time.get_mut(chunk).ok_or_else(|| anyhow!("Chunk out of bounds"))
     }
 
     pub fn update(&mut self, chunk: usize) -> Result<()> {
         let time = self.timer.elapsed().as_secs() as u32;
-        if *self.get_modified_time(chunk)? != 0 {
-            self.remove_chunk(chunk)?;
-        }
-        *self.get_modified_time(chunk)? = time;
+        // drop the previous queue entry first, otherwise the chunk would be left in the
+        // queue twice under two different times
+        self.remove_chunk(chunk)?;
+        *self.get_modified_time(chunk)? = Some(time);
         self.queue.insert((time, chunk));
         Ok(())
     }
@@ -42,9 +45,10 @@ impl ChunkTracker {
     }
 
     pub fn remove_chunk(&mut self, chunk: usize) -> Result<()> {
-        let time = *self.get_modified_time(chunk)?;
-        self.queue.remove(&(time, chunk));
-        *self.get_modified_time(chunk)? = 0;
+        if let Some(time) = *self.get_modified_time(chunk)? {
+            self.queue.remove(&(time, chunk));
+            *self.get_modified_time(chunk)? = None;
+        }
         Ok(())
     }
 }

--- a/client/game/mod.rs
+++ b/client/game/mod.rs
@@ -19,5 +19,6 @@ mod pause_menu;
 mod players;
 pub mod private_world;
 mod respawn_screen;
+mod tests;
 pub mod tls_client;
 mod walls;

--- a/client/game/tests.rs
+++ b/client/game/tests.rs
@@ -1,0 +1,102 @@
+#![allow(clippy::unwrap_used)]
+#![cfg(test)]
+mod tests {
+    use crate::client::game::chunk_tracker::ChunkTracker;
+
+    #[test]
+    fn test_new_tracker_is_empty() {
+        let tracker = ChunkTracker::new(4);
+        assert_eq!(tracker.get_num_chunks(), 0);
+        assert!(tracker.get_oldest_chunk().is_err());
+    }
+
+    #[test]
+    fn test_out_of_bounds_chunk() {
+        let mut tracker = ChunkTracker::new(2);
+        assert!(tracker.update(2).is_err());
+        assert!(tracker.remove_chunk(9).is_err());
+    }
+
+    #[test]
+    fn test_update_then_remove() {
+        let mut tracker = ChunkTracker::new(4);
+
+        tracker.update(1).unwrap();
+        assert_eq!(tracker.get_num_chunks(), 1);
+        assert_eq!(tracker.get_oldest_chunk().unwrap(), 1);
+
+        tracker.remove_chunk(1).unwrap();
+        assert_eq!(tracker.get_num_chunks(), 0);
+    }
+
+    /// Removing a chunk that was never tracked is a no-op, not an error and not a
+    /// corrupted queue.
+    #[test]
+    fn test_remove_untracked_chunk_is_a_noop() {
+        let mut tracker = ChunkTracker::new(4);
+
+        tracker.update(0).unwrap();
+        tracker.remove_chunk(2).unwrap();
+
+        assert_eq!(tracker.get_num_chunks(), 1);
+        assert_eq!(tracker.get_oldest_chunk().unwrap(), 0);
+    }
+
+    /// Touching the same chunk repeatedly must never make it count more than once.
+    #[test]
+    fn test_repeated_update_counts_once() {
+        let mut tracker = ChunkTracker::new(4);
+
+        for _ in 0..5 {
+            tracker.update(3).unwrap();
+        }
+
+        assert_eq!(tracker.get_num_chunks(), 1);
+    }
+
+    /// The tracker used to store `0` to mean "not tracked", which collides with a real
+    /// elapsed time of 0 seconds - that is every update during the tracker's first
+    /// second of life. A chunk first touched in that window was never removed from the
+    /// queue on its next update, so it appeared twice under two different times:
+    /// `get_num_chunks` over-reported and `get_oldest_chunk` kept returning a chunk that
+    /// had just been used.
+    ///
+    /// This needs a real second to pass, since the collision only shows up once
+    /// `timer.elapsed().as_secs()` moves off 0.
+    #[test]
+    fn test_chunk_touched_in_the_first_second_is_not_duplicated() {
+        let mut tracker = ChunkTracker::new(4);
+
+        // recorded at elapsed time 0
+        tracker.update(0).unwrap();
+        assert_eq!(tracker.get_num_chunks(), 1);
+
+        std::thread::sleep(std::time::Duration::from_millis(1050));
+
+        // recorded at elapsed time 1, must replace the entry rather than add a second one
+        tracker.update(0).unwrap();
+        assert_eq!(tracker.get_num_chunks(), 1, "chunk 0 was queued twice under two different times");
+
+        // and the queue must be genuinely empty after removing that one chunk
+        tracker.remove_chunk(0).unwrap();
+        assert_eq!(tracker.get_num_chunks(), 0, "a stale queue entry survived removal");
+    }
+
+    #[test]
+    fn test_oldest_chunk_is_the_least_recently_updated() {
+        let mut tracker = ChunkTracker::new(4);
+
+        tracker.update(0).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1050));
+        tracker.update(1).unwrap();
+
+        assert_eq!(tracker.get_oldest_chunk().unwrap(), 0);
+
+        // Touching chunk 0 again makes chunk 1 the oldest. This needs another second to
+        // pass: the tracker's resolution is whole seconds, so an update inside the same
+        // second as chunk 1's ties on time and falls back to ordering by chunk index.
+        std::thread::sleep(std::time::Duration::from_millis(1050));
+        tracker.update(0).unwrap();
+        assert_eq!(tracker.get_oldest_chunk().unwrap(), 1);
+    }
+}

--- a/shared/lights.rs
+++ b/shared/lights.rs
@@ -119,7 +119,10 @@ impl Lights {
     /// creates an empty light vector
     pub fn create(&mut self, size: (u32, u32)) {
         self.lights = vec![Light::new(); (size.0 * size.1) as usize];
-        self.light_chunks = vec![LightChunk::new(); (size.0 as i32 / CHUNK_SIZE * size.1 as i32 / CHUNK_SIZE) as usize];
+        // the parentheses matter: `/` and `*` are left associative, so without them this
+        // reads as `((w / CHUNK_SIZE) * h) / CHUNK_SIZE`, which is a different number
+        // whenever the height is not a multiple of CHUNK_SIZE
+        self.light_chunks = vec![LightChunk::new(); ((size.0 as i32 / CHUNK_SIZE) * (size.1 as i32 / CHUNK_SIZE)) as usize];
         self.map = WorldMap::new(size);
         self.sky_heights = vec![-1; size.0 as usize];
     }
@@ -251,14 +254,14 @@ impl Lights {
             let curr_block_transparent = blocks.get_block_type_at(event.x, event.y)?.transparent;
             let prev_block_transparent = blocks.get_block_type(event.prev_block)?.transparent;
 
-            if curr_block_transparent && !prev_block_transparent && *self.sky_heights.get(event.x as usize).unwrap_or(&0) == event.y - 1 {
+            if curr_block_transparent && !prev_block_transparent && *self.sky_heights.get(event.x as usize).unwrap_or(&-1) == event.y - 1 {
                 let mut sky_height = event.y;
                 while sky_height < self.get_size().1 as i32 && blocks.get_block_type_at(event.x, sky_height)?.transparent {
                     sky_height += 1;
                 }
 
                 *self.sky_heights.get_mut(event.x as usize).ok_or_else(|| anyhow!("sky_heights out of bounds"))? = sky_height - 1;
-            } else if !curr_block_transparent && prev_block_transparent && *self.sky_heights.get(event.x as usize).unwrap_or(&0) >= event.y {
+            } else if !curr_block_transparent && prev_block_transparent && *self.sky_heights.get(event.x as usize).unwrap_or(&-1) >= event.y {
                 *self.sky_heights.get_mut(event.x as usize).ok_or_else(|| anyhow!("sky_heights out of bounds"))? = event.y - 1;
             }
 


### PR DESCRIPTION
## ChunkTracker: `0` meant two different things

`modified_time` stored `0` to mean "not tracked" — but `0` is also a real value of `timer.elapsed().as_secs()`, for the **whole first second the tracker is alive**.

A chunk first touched in that window looked untracked on its next update, so the old queue entry was never removed and the chunk ended up in the queue **twice, under two different times**.

That matters because all three callers — `blocks.rs`, `walls.rs`, `lights.rs` — drive eviction like this:

```rust
while self.chunk_tracker.get_num_chunks() > MAX_LOADED_CHUNKS {
    let chunk_index = self.chunk_tracker.get_oldest_chunk()?;
    ...
    self.chunk_tracker.remove_chunk(chunk_index)?;
}
```

So the duplicate makes `get_num_chunks` over-report and `get_oldest_chunk` hand back a chunk that was **just used** — evicting live chunks and immediately reloading them.

**Fix:** `modified_time` becomes `Vec<Option<u32>>`, `update` unconditionally removes the previous entry first, and `remove_chunk` on an untracked chunk is a clean no-op instead of removing the bogus `(0, chunk)` key.

## Tests

New `client/game/tests.rs`, 7 tests. The two time-dependent ones each wait a real second, because the collision only appears once `elapsed().as_secs()` moves off `0`. Verified against the old implementation:

```
test test_chunk_touched_in_the_first_second_is_not_duplicated ... FAILED
test test_oldest_chunk_is_the_least_recently_updated ... FAILED
```

Both pass on this branch.

One of them caught my own wrong assumption while writing it: within the same second two chunks tie on time and the `BTreeSet` falls back to ordering by chunk index. The test now waits out the second and says so, rather than asserting something the tracker's 1-second resolution can't provide.

## Lights: operator precedence

```rust
size.0 as i32 / CHUNK_SIZE * size.1 as i32 / CHUNK_SIZE
```

`/` and `*` are left-associative, so this reads as `((w / 16) * h) / 16`, not `(w / 16) * (h / 16)`.

Being straight about the impact: these agree for the default 4400×1200 world, and where they differ the first is *larger* — so it over-allocates rather than truncating. **No observable bug today**, and it isn't reachable through the public API, which is why it ships without a test. It's simply not the expression that was meant, and it'll bite the first time someone picks a height that isn't a multiple of 16.

## Also

The two `sky_heights` lookups in `on_event` used `unwrap_or(&0)` while `init_sky_heights` defaults to `-1`. Both fall through to the same error on an out-of-bounds `x`, so this is consistency only — not a behaviour change.

## Verification

`cargo test` 46/46, clippy clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)