### PR TITLE
Make break_time of None consistently mean unbreakable

### DIFF
--- a/shared/blocks/breaking.rs
+++ b/shared/blocks/breaking.rs
@@ -6,6 +6,10 @@ use crate::shared::blocks::{BlockId, ToolId};
 
 use super::Blocks;
 
+/// How many frames the breaking overlay texture (`misc:breaking.opa`, 8x64) has.
+/// A break stage is an index into it, so the valid range is `0..BREAK_STAGES`.
+pub const BREAK_STAGES: i32 = 8;
+
 /// Breaking block struct represents a block that is currently being broken.
 #[derive(Clone)]
 pub struct BreakingBlock {
@@ -43,6 +47,12 @@ impl Blocks {
         // check if coordinates are out of bounds
         self.block_data.map.translate_coords(x, y)?;
 
+        // an unbreakable block must never enter the breaking list, or update_breaking_blocks
+        // would go on to break it - start_breaking_block already refuses these
+        if self.get_block_type_at(x, y)?.break_time.is_none() {
+            return Ok(());
+        }
+
         for breaking_block in &mut self.breaking_blocks {
             if breaking_block.coord == (x, y) {
                 breaking_block.break_progress = progress;
@@ -58,8 +68,18 @@ impl Blocks {
     }
 
     /// Gets the break stage of a block, which is rendered.
+    /// An unbreakable block never shows breaking progress, and the result is always a
+    /// valid index into the breaking texture.
     pub fn get_break_stage(&self, x: i32, y: i32) -> Result<i32> {
-        Ok((self.get_break_progress(x, y)? as f32 / self.get_block_type_at(x, y)?.break_time.unwrap_or(0) as f32 * 8.0) as i32)
+        let Some(break_time) = self.get_block_type_at(x, y)?.break_time else {
+            return Ok(0);
+        };
+
+        if break_time <= 0 {
+            return Ok(0);
+        }
+
+        Ok((self.get_break_progress(x, y)? * BREAK_STAGES / break_time).clamp(0, BREAK_STAGES - 1))
     }
 
     /// Adds a block to the breaking list, which means that the block is being broken.
@@ -119,7 +139,13 @@ impl Blocks {
 
         let mut broken_blocks = Vec::new();
         for breaking_block in &self.breaking_blocks {
-            if breaking_block.break_progress > self.get_block_type_at(breaking_block.coord.0, breaking_block.coord.1)?.break_time.unwrap_or(1) {
+            // break_time of None means unbreakable, so such a block never completes.
+            // It used to fall back to 1, which broke it on the very next update.
+            let Some(break_time) = self.get_block_type_at(breaking_block.coord.0, breaking_block.coord.1)?.break_time else {
+                continue;
+            };
+
+            if breaking_block.break_progress > break_time {
                 broken_blocks.push(breaking_block.coord);
             }
         }

--- a/shared/blocks/tests.rs
+++ b/shared/blocks/tests.rs
@@ -7,6 +7,7 @@ mod tests {
     use crate::shared::blocks::Block;
     use crate::shared::blocks::BlockChangeEvent;
     use crate::shared::blocks::Blocks;
+    use crate::shared::blocks::BREAK_STAGES;
 
     #[test]
     fn test_blocks_new() {
@@ -150,5 +151,85 @@ mod tests {
 
         let event = events.pop_event();
         assert!(event.is_none());
+    }
+
+    /// Builds a 5x5 world with a breakable and an unbreakable block type registered.
+    fn blocks_with_break_types() -> (Blocks, crate::shared::blocks::BlockId, crate::shared::blocks::BlockId) {
+        let mut blocks = Blocks::new();
+
+        let mut breakable = Block::new();
+        breakable.name = "breakable".to_owned();
+        breakable.break_time = Some(1000);
+        let breakable_id = blocks.register_new_block_type(breakable);
+
+        let mut unbreakable = Block::new();
+        unbreakable.name = "unbreakable".to_owned();
+        unbreakable.break_time = None;
+        let unbreakable_id = blocks.register_new_block_type(unbreakable);
+
+        blocks.create((5, 5));
+
+        (blocks, breakable_id, unbreakable_id)
+    }
+
+    /// `set_break_progress` is a second way into the breaking list, and unlike
+    /// `start_breaking_block` it did not check whether the block can be broken at all.
+    /// `update_breaking_blocks` then compared against `break_time.unwrap_or(1)`, so an
+    /// unbreakable block was destroyed on the very next update.
+    #[test]
+    fn test_set_break_progress_cannot_destroy_an_unbreakable_block() {
+        let (mut blocks, _breakable, unbreakable) = blocks_with_break_types();
+        let mut events = EventManager::new();
+
+        blocks.set_block(&mut events, 1, 1, unbreakable).unwrap();
+        blocks.set_break_progress(1, 1, 5000).unwrap();
+        blocks.update_breaking_blocks(&mut events, 0.0).unwrap();
+
+        assert!(blocks.get_block(1, 1).unwrap() == unbreakable, "an unbreakable block was destroyed");
+    }
+
+    /// An unbreakable block has no break time to measure progress against, so it shows
+    /// no breaking overlay. This used to divide by zero and saturate to i32::MAX.
+    #[test]
+    fn test_break_stage_of_unbreakable_block_is_zero() {
+        let (mut blocks, _breakable, unbreakable) = blocks_with_break_types();
+        let mut events = EventManager::new();
+
+        blocks.set_block(&mut events, 1, 1, unbreakable).unwrap();
+        blocks.set_break_progress(1, 1, 500).unwrap();
+
+        assert_eq!(blocks.get_break_stage(1, 1).unwrap(), 0);
+    }
+
+    /// The break stage indexes the 8 frame breaking texture, so it has to stay in range
+    /// even when progress has reached break_time.
+    #[test]
+    fn test_break_stage_stays_in_texture_range() {
+        let (mut blocks, breakable, _unbreakable) = blocks_with_break_types();
+        let mut events = EventManager::new();
+
+        blocks.set_block(&mut events, 1, 1, breakable).unwrap();
+
+        for progress in [0, 1, 500, 999, 1000] {
+            blocks.set_break_progress(1, 1, progress).unwrap();
+            let stage = blocks.get_break_stage(1, 1).unwrap();
+            assert!((0..BREAK_STAGES).contains(&stage), "progress {progress} gave break stage {stage}, outside 0..{BREAK_STAGES}");
+        }
+    }
+
+    /// A breakable block still breaks normally.
+    #[test]
+    fn test_breakable_block_still_breaks() {
+        let (mut blocks, breakable, _unbreakable) = blocks_with_break_types();
+        let mut events = EventManager::new();
+
+        blocks.set_block(&mut events, 1, 1, breakable).unwrap();
+        blocks.start_breaking_block(&mut events, 1, 1, None, 0).unwrap();
+
+        for _ in 0..3 {
+            blocks.update_breaking_blocks(&mut events, 1000.0).unwrap();
+        }
+
+        assert!(blocks.get_block(1, 1).unwrap() == blocks.air(), "a breakable block was not broken");
     }
 }

--- a/shared/walls/breaking.rs
+++ b/shared/walls/breaking.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 use crate::libraries::events::EventManager;
+use crate::shared::blocks::BREAK_STAGES;
 use crate::shared::walls::Walls;
 
 /// Stores the info about a breaking progress about a wall.
@@ -35,8 +36,18 @@ impl Walls {
     }
 
     /// Returns the break stage (for example to be used as a break texture stage) of the wall at x and y
+    /// An unbreakable wall never shows breaking progress, and the result is always a
+    /// valid index into the breaking texture.
     pub fn get_break_stage(&self, x: i32, y: i32) -> Result<i32> {
-        Ok(self.get_break_progress(x, y)? * 9 / self.get_wall_type_at(x, y)?.break_time.unwrap_or(1))
+        let Some(break_time) = self.get_wall_type_at(x, y)?.break_time else {
+            return Ok(0);
+        };
+
+        if break_time <= 0 {
+            return Ok(0);
+        }
+
+        Ok((self.get_break_progress(x, y)? * BREAK_STAGES / break_time).clamp(0, BREAK_STAGES - 1))
     }
 
     /// Includes the necessary steps to start breaking a wall, such as adding it to the
@@ -90,7 +101,13 @@ impl Walls {
 
         let mut broken_walls = Vec::new();
         for breaking_wall in &self.breaking_walls {
-            if breaking_wall.break_progress > self.get_wall_type_at(breaking_wall.coord.0, breaking_wall.coord.1)?.break_time.unwrap_or(1) {
+            // break_time of None means unbreakable, so such a wall never completes.
+            // It used to fall back to 1, which broke it on the very next update.
+            let Some(break_time) = self.get_wall_type_at(breaking_wall.coord.0, breaking_wall.coord.1)?.break_time else {
+                continue;
+            };
+
+            if breaking_wall.break_progress > break_time {
                 broken_walls.push(breaking_wall.coord);
             }
         }

--- a/shared/walls/tests.rs
+++ b/shared/walls/tests.rs
@@ -1,3 +1,99 @@
+#![allow(clippy::unwrap_used)]
 #![cfg(test)]
+mod tests {
+    use crate::libraries::events::EventManager;
+    use crate::shared::blocks::{Blocks, BREAK_STAGES};
+    use crate::shared::walls::{Wall, Walls};
 
-mod tests {}
+    /// Builds a 5x5 world of walls with one breakable and one unbreakable type.
+    /// Returns the walls plus the ids, with the whole map set to the breakable type.
+    fn walls_with_types() -> (Walls, crate::shared::walls::WallId, crate::shared::walls::WallId) {
+        let mut blocks = Blocks::new();
+        let mut walls = Walls::new(&mut blocks);
+
+        let mut breakable = Wall::new();
+        breakable.name = "breakable".to_owned();
+        breakable.break_time = Some(1000);
+        let breakable_id = Walls::register_new_wall_type(&mut walls.wall_types, breakable);
+
+        let mut unbreakable = Wall::new();
+        unbreakable.name = "unbreakable".to_owned();
+        unbreakable.break_time = None;
+        let unbreakable_id = Walls::register_new_wall_type(&mut walls.wall_types, unbreakable);
+
+        walls.create((5, 5));
+
+        (walls, breakable_id, unbreakable_id)
+    }
+
+    /// An unbreakable wall must never break, however long it is hit for.
+    ///
+    /// This passes on the old code too: `start_breaking_wall` is the only way into
+    /// `breaking_walls` and it already refuses unbreakable walls, so the `unwrap_or(1)`
+    /// in `update_breaking_walls` was unreachable. Blocks are the ones with a second,
+    /// unguarded entry point. Kept as a guard against that changing.
+    #[test]
+    fn test_unbreakable_wall_never_breaks() {
+        let (mut walls, _breakable, unbreakable) = walls_with_types();
+        let mut events = EventManager::new();
+
+        walls.set_wall_type(1, 1, unbreakable).unwrap();
+        walls.start_breaking_wall(1, 1).unwrap();
+
+        for _ in 0..100 {
+            walls.update_breaking_walls(1000.0, &mut events).unwrap();
+        }
+
+        assert!(walls.get_wall_type_at(1, 1).unwrap().get_id() == unbreakable, "an unbreakable wall was broken");
+    }
+
+    #[test]
+    fn test_breakable_wall_breaks() {
+        let (mut walls, breakable, _unbreakable) = walls_with_types();
+        let mut events = EventManager::new();
+
+        walls.set_wall_type(1, 1, breakable).unwrap();
+        walls.start_breaking_wall(1, 1).unwrap();
+
+        for _ in 0..10 {
+            walls.update_breaking_walls(1000.0, &mut events).unwrap();
+        }
+
+        assert!(walls.get_wall_type_at(1, 1).unwrap().get_id() != breakable, "a breakable wall was not broken");
+    }
+
+    /// The break stage indexes the breaking texture, so it has to stay in range even
+    /// when progress has run past break_time.
+    #[test]
+    fn test_break_stage_stays_in_texture_range() {
+        let (mut walls, breakable, unbreakable) = walls_with_types();
+
+        walls.set_wall_type(0, 0, unbreakable).unwrap();
+        assert_eq!(walls.get_break_stage(0, 0).unwrap(), 0, "an unbreakable wall should show no breaking");
+
+        walls.set_wall_type(1, 1, breakable).unwrap();
+        walls.start_breaking_wall(1, 1).unwrap();
+
+        let mut events = EventManager::new();
+
+        // Advance exactly to break_time. The wall is not removed until progress goes
+        // strictly past it, so this is a real state the renderer can observe - and it is
+        // where the old `progress * 9 / break_time` produced 9, two rows past the end of
+        // the 8 frame breaking texture.
+        walls.update_breaking_walls(1000.0, &mut events).unwrap();
+        assert_eq!(walls.get_break_progress(1, 1).unwrap(), 1000, "test setup: expected progress to sit exactly on break_time");
+
+        let stage = walls.get_break_stage(1, 1).unwrap();
+        assert!((0..BREAK_STAGES).contains(&stage), "break stage {stage} is outside 0..{BREAK_STAGES}");
+    }
+
+    #[test]
+    fn test_start_breaking_ignores_unbreakable() {
+        let (mut walls, _breakable, unbreakable) = walls_with_types();
+
+        walls.set_wall_type(2, 2, unbreakable).unwrap();
+        walls.start_breaking_wall(2, 2).unwrap();
+
+        assert_eq!(walls.get_break_progress(2, 2).unwrap(), 0);
+    }
+}


### PR DESCRIPTION
## The inconsistency

Three functions disagreed about what `break_time: None` means:

| | treats `None` as |
|---|---|
| `start_breaking_block` | unbreakable — refuses |
| `update_breaking_blocks` | `unwrap_or(1)` → breaks in **1 ms** |
| `get_break_stage` | `unwrap_or(0)` → **divide by zero** |

### Blocks: reachable

`set_break_progress` is a **second way into the breaking list** — driven by `BlockBreakStopPacket` from the server — and it had no unbreakable check. A block with no break time put there is destroyed on the next update. `get_break_stage` on it divides by zero, giving `inf`, which saturates to `i32::MAX` when cast to the texture row index.

### Walls: not reachable

`start_breaking_wall` is the *only* way into `breaking_walls` and it already guards, so the matching `unwrap_or(1)` was dead defensive code. Hardened anyway so the two stay in step — but I've written the test's doc comment to say plainly that it passes against the old code too, rather than implying it caught something.

## What *is* reachable for walls: the break stage

```rust
self.get_break_progress(x, y)? * 9 / break_time
```

yields **9** once progress reaches `break_time` — and the wall isn't removed until progress goes *strictly* past it, so that value really does get rendered. `misc:breaking.opa` is 8×64, i.e. **8 frames**, so both 8 and 9 are past the end. The block side had the same problem from the other direction, `* 8.0` reaching exactly 8.

Adds `BREAK_STAGES = 8` next to the breaking logic, tied to the texture it indexes, and clamps both break stages into `0..BREAK_STAGES`.

## Tests

4 new in `shared/blocks/tests.rs`; `shared/walls/tests.rs` goes from an empty `mod tests {}` stub to 4 tests.

Verified against the old code — **4 of the 8 fail**:

```
test shared::blocks::tests::tests::test_set_break_progress_cannot_destroy_an_unbreakable_block ... FAILED
test shared::blocks::tests::tests::test_break_stage_of_unbreakable_block_is_zero ... FAILED
test shared::blocks::tests::tests::test_break_stage_stays_in_texture_range ... FAILED
test shared::walls::tests::tests::test_break_stage_stays_in_texture_range ... FAILED
```

My first attempt at these tests passed against the old code — the wall setup never reached `progress == break_time`, and the unbreakable wall path was already guarded. Worth mentioning because it's the reason the wall test now advances to exactly `break_time` and asserts that as a setup precondition.

`cargo test` 47/47, clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)