### PR TITLE
Make the spawn point search match its comment and stop early

### DIFF
--- a/server/server_core/players.rs
+++ b/server/server_core/players.rs
@@ -42,25 +42,27 @@ impl ServerPlayers {
         }
     }
 
-    fn get_spawn_coords(blocks: &Blocks) -> (f32, f32) {
+    /// Finds a spawn point in the middle column of the map: the first tile from the top
+    /// that the player cannot walk through, with the player placed directly on top of it.
+    pub(super) fn get_spawn_coords(blocks: &Blocks) -> (f32, f32) {
         let spawn_x = blocks.get_size().0 as f32 / 2.0;
-        let mut spawn_y = 0.0;
-        // find a spawn point
-        // iterate from the top of the map to the bottom
-        for y in (0..blocks.get_size().1).rev() {
+
+        // y grows downwards, so this really does walk from the top of the map down
+        for y in 0..blocks.get_size().1 {
             for x in 0..(PLAYER_WIDTH.ceil() as i32) {
                 let block_type = blocks.get_block_type(blocks.get_block(spawn_x as i32 + x, y as i32).unwrap_or_else(|_| blocks.air()));
 
                 let is_ghost = block_type.ok().map_or(false, |block_type| block_type.ghost);
 
                 if !is_ghost {
-                    spawn_y = y as f32 - PLAYER_HEIGHT;
-                    break;
+                    return (spawn_x, y as f32 - PLAYER_HEIGHT);
                 }
             }
         }
 
-        (spawn_x, spawn_y)
+        // Nothing solid anywhere in the column. Put the player at the bottom of the map
+        // rather than at y 0, where they would fall the entire height of the world.
+        (spawn_x, blocks.get_size().1 as f32 - PLAYER_HEIGHT)
     }
 
     pub fn handle_client_packet(

--- a/server/server_core/tests.rs
+++ b/server/server_core/tests.rs
@@ -1,8 +1,12 @@
 #![allow(clippy::unwrap_used)]
 #![cfg(test)]
 mod tests {
+    use crate::libraries::events::EventManager;
     use crate::server::server_core::commands::CommandManager;
+    use crate::server::server_core::players::ServerPlayers;
+    use crate::shared::blocks::{Block, Blocks};
     use crate::shared::mod_manager::ModManager;
+    use crate::shared::players::PLAYER_HEIGHT;
 
     /// Runs a command against a `CommandManager` that has no mods loaded.
     fn execute(command: &str) -> anyhow::Result<String> {
@@ -45,5 +49,82 @@ mod tests {
     #[test]
     fn test_help_with_too_many_arguments() {
         assert!(execute("help one two").is_err());
+    }
+
+    /// Builds a world of the given size that is solid from `ground_y` downwards.
+    fn world_with_ground_at(size: (u32, u32), ground_y: Option<u32>) -> Blocks {
+        let mut blocks = Blocks::new();
+
+        let mut solid = Block::new();
+        solid.name = "solid".to_owned();
+        solid.ghost = false;
+        let solid_id = blocks.register_new_block_type(solid);
+
+        blocks.create(size);
+
+        if let Some(ground_y) = ground_y {
+            let mut events = EventManager::new();
+            for x in 0..size.0 {
+                for y in ground_y..size.1 {
+                    blocks.set_block(&mut events, x as i32, y as i32, solid_id).unwrap();
+                }
+            }
+        }
+
+        blocks
+    }
+
+    /// The player is placed standing on the first solid tile from the top.
+    #[test]
+    fn test_spawn_lands_on_the_surface() {
+        let blocks = world_with_ground_at((32, 64), Some(40));
+        let (x, y) = ServerPlayers::get_spawn_coords(&blocks);
+
+        assert!((x - 16.0).abs() < f32::EPSILON, "expected the middle column, got {x}");
+        assert!((y - (40.0 - PLAYER_HEIGHT)).abs() < f32::EPSILON, "expected to stand on the ground at y=40, got {y}");
+    }
+
+    /// Ghost blocks are walked through, so a layer of them above the ground does not
+    /// become the spawn point.
+    #[test]
+    fn test_spawn_ignores_ghost_blocks() {
+        let mut blocks = Blocks::new();
+
+        let mut ghost = Block::new();
+        ghost.name = "ghost".to_owned();
+        ghost.ghost = true;
+        let ghost_id = blocks.register_new_block_type(ghost);
+
+        let mut solid = Block::new();
+        solid.name = "solid".to_owned();
+        solid.ghost = false;
+        let solid_id = blocks.register_new_block_type(solid);
+
+        blocks.create((32, 64));
+
+        let mut events = EventManager::new();
+        for x in 0..32 {
+            // a band of ghost blocks well above the ground, like foliage
+            for y in 10..20 {
+                blocks.set_block(&mut events, x, y, ghost_id).unwrap();
+            }
+            for y in 40..64 {
+                blocks.set_block(&mut events, x, y, solid_id).unwrap();
+            }
+        }
+
+        let (_x, y) = ServerPlayers::get_spawn_coords(&blocks);
+        assert!((y - (40.0 - PLAYER_HEIGHT)).abs() < f32::EPSILON, "spawned on the ghost band instead of the ground, got {y}");
+    }
+
+    /// A column with nothing solid in it puts the player at the bottom of the map, not
+    /// at the very top where they would fall the whole height of the world.
+    #[test]
+    fn test_spawn_in_an_empty_world() {
+        let blocks = world_with_ground_at((32, 64), None);
+        let (_x, y) = ServerPlayers::get_spawn_coords(&blocks);
+
+        assert!(y > 0.0, "an empty column should not spawn the player at the top of the map, got {y}");
+        assert!((y - (64.0 - PLAYER_HEIGHT)).abs() < f32::EPSILON, "expected the bottom of the map, got {y}");
     }
 }


### PR DESCRIPTION
> **Stacked on #168**, which adds `server/server_core/tests.rs`. Base retargets to `master` automatically once that merges. The diff shown here is just this change.

## What was there

```rust
let mut spawn_y = 0.0;
// find a spawn point
// iterate from the top of the map to the bottom
for y in (0..blocks.get_size().1).rev() {      // <- .rev() is bottom to top
    for x in 0..(PLAYER_WIDTH.ceil() as i32) {
        ...
        if !is_ghost {
            spawn_y = y as f32 - PLAYER_HEIGHT;
            break;                              // <- only leaves the x loop
        }
    }
}
```

Three things disagree: the comment says top-to-bottom, `.rev()` goes bottom-to-top, and the `break` only leaves the inner loop — so the outer loop always runs the full world height and the answer falls out of last-write-wins.

## Scope: this is not a behaviour change for real worlds

Being straight about this, since I'd flagged it as a suspected bug earlier. **The old code's answer is correct.** I had suspected players could spawn on tree canopies — they can't: `canopy`, `leaves`, `branch`, `wood` and `grass` are all registered with `ghost = true` in `base_game`, so the search walks straight through them to the ground.

Verified rather than assumed — against the old implementation, only 1 of the 3 new tests fails:

```
test test_spawn_lands_on_the_surface  ... ok
test test_spawn_ignores_ghost_blocks  ... ok
test test_spawn_in_an_empty_world     ... FAILED
```

## What does change

- **Reads top-to-bottom**, as the comment always claimed, and **returns as soon as it finds the tile** — instead of scanning all 1200 rows on every spawn and respawn.
- **A column with nothing solid** no longer leaves `spawn_y` at `0.0`, which put the player at the very top of the map to fall the entire height of the world. They now start at the bottom. This is the one real behaviour fix.
- The intent is **local** rather than depending on the last iteration winning, so a mod that registers a non-ghost block above ground level has an obvious place to look.

`get_spawn_coords` becomes `pub(super)` so the tests can call it.

## Verification

`cargo test` 47/47, clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)