### PR TITLE
Let dedicated servers accept connections from the network

### DIFF
--- a/client/game/private_world.rs
+++ b/client/game/private_world.rs
@@ -13,7 +13,7 @@ use crate::client::menus::{LoadingScreen, Menu};
 use crate::client::settings::Settings;
 use crate::libraries::graphics as gfx;
 use crate::server::server_core::Server;
-use crate::server::server_core::SINGLEPLAYER_PORT;
+use crate::server::server_core::{BindAddress, SINGLEPLAYER_PORT};
 
 fn start_private_world_server(world_path: &Path) -> Result<(std::thread::JoinHandle<std::result::Result<(), anyhow::Error>>, Arc<AtomicBool>, Arc<Mutex<String>>)> {
     let server_running = Arc::new(AtomicBool::new(true));
@@ -25,7 +25,8 @@ fn start_private_world_server(world_path: &Path) -> Result<(std::thread::JoinHan
     let world_path = world_path.to_owned();
 
     let server_thread = std::thread::Builder::new().name("Private server".to_owned()).spawn(move || {
-        let mut server = Server::new(SINGLEPLAYER_PORT, None, None);
+        // loopback only: a singleplayer world must not be reachable from the network
+        let mut server = Server::new(SINGLEPLAYER_PORT, BindAddress::Loopback, None, None);
         let result = server.run(&server_running2, &loading_text2, vec![include_bytes!("../../base_game/base_game.mod").to_vec()], &world_path);
 
         if result.is_err() {

--- a/main.rs
+++ b/main.rs
@@ -165,7 +165,7 @@ use crate::client::global_settings::GlobalSettings;
 use crate::client::menus::{run_title_screen, MenuBack};
 use crate::client::settings::Settings;
 use crate::libraries::graphics as gfx;
-use crate::server::server_core::{Server, MULTIPLAYER_PORT};
+use crate::server::server_core::{BindAddress, Server, MULTIPLAYER_PORT};
 use crate::server::server_ui::UiManager;
 
 pub mod libraries {
@@ -256,9 +256,9 @@ fn server_main(args: &[String]) {
     let (ui_to_srv_event_sender, ui_to_srv_event_receiver) = std::sync::mpsc::channel();
 
     let mut server = if server_graphics_context.is_some() {
-        Server::new(MULTIPLAYER_PORT, Some(ui_to_srv_event_receiver), Some(srv_to_ui_event_sender))
+        Server::new(MULTIPLAYER_PORT, BindAddress::AllInterfaces, Some(ui_to_srv_event_receiver), Some(srv_to_ui_event_sender))
     } else {
-        Server::new(MULTIPLAYER_PORT, None, None)
+        Server::new(MULTIPLAYER_PORT, BindAddress::AllInterfaces, None, None)
     };
 
     if let Some(graphics) = server_graphics_context {

--- a/server/server_core/core_server.rs
+++ b/server/server_core/core_server.rs
@@ -20,7 +20,7 @@ use crate::server::server_ui::{ConsoleMessageType, PlayerEventType, ServerState,
 use super::blocks::ServerBlocks;
 use super::commands::CommandManager;
 use super::mod_manager::ServerModManager;
-use super::networking::ServerNetworking;
+use super::networking::{BindAddress, ServerNetworking};
 use super::walls::ServerWalls;
 use super::world_generator::WorldGenerator;
 
@@ -44,7 +44,7 @@ pub struct Server {
 
 impl Server {
     #[must_use]
-    pub fn new(port: u16, ui_event_receiver: Option<Receiver<UiMessageType>>, ui_event_sender: Option<Sender<UiMessageType>>) -> Self {
+    pub fn new(port: u16, bind_address: BindAddress, ui_event_receiver: Option<Receiver<UiMessageType>>, ui_event_sender: Option<Sender<UiMessageType>>) -> Self {
         send_to_ui(UiMessageType::ServerState(ServerState::Nothing), ui_event_sender); //this is useless but sets the ui event sender
         let blocks = ServerBlocks::new();
         let walls = ServerWalls::new(&mut blocks.get_blocks());
@@ -53,7 +53,7 @@ impl Server {
             tps_limit: 20.0,
             state: Arc::new(Mutex::new(ServerState::Nothing)),
             events: EventManager::new(),
-            networking: ServerNetworking::new(port),
+            networking: ServerNetworking::new(port, bind_address),
             mods: ServerModManager::new(Vec::new()),
             blocks,
             walls,

--- a/server/server_core/mod.rs
+++ b/server/server_core/mod.rs
@@ -1,4 +1,5 @@
 pub use core_server::{print_to_console, send_to_ui, Server, MULTIPLAYER_PORT, SINGLEPLAYER_PORT};
+pub use networking::BindAddress;
 
 mod blocks;
 mod chat;

--- a/server/server_core/networking.rs
+++ b/server/server_core/networking.rs
@@ -40,11 +40,32 @@ pub enum SendTarget {
     AllExcept(Connection),
 }
 
+/// Which interfaces a server accepts connections on.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BindAddress {
+    /// Only this machine can connect. This is what the singleplayer server uses, and it
+    /// must stay that way - a singleplayer world should never be reachable from the network.
+    Loopback,
+    /// Every interface, so players on other machines can join. Used by the dedicated server.
+    AllInterfaces,
+}
+
+impl BindAddress {
+    #[must_use]
+    pub const fn as_ip(self) -> &'static str {
+        match self {
+            Self::Loopback => "127.0.0.1",
+            Self::AllInterfaces => "0.0.0.0",
+        }
+    }
+}
+
 /// This handles all the networking for the server.
 /// server listens for connections and sends and receives packets
 /// for each client.
 pub struct ServerNetworking {
     server_port: u16,
+    bind_address: BindAddress,
     connections: Vec<Connection>,
     connection_names: HashMap<Connection, String>,
     event_receiver: Option<Receiver<Event>>,
@@ -54,9 +75,10 @@ pub struct ServerNetworking {
 }
 
 impl ServerNetworking {
-    pub fn new(server_port: u16) -> Self {
+    pub fn new(server_port: u16, bind_address: BindAddress) -> Self {
         Self {
             server_port,
+            bind_address,
             connections: Vec::new(),
             connection_names: HashMap::new(),
             event_receiver: None,
@@ -80,24 +102,33 @@ impl ServerNetworking {
 
         let is_running = self.is_running.clone();
         let server_port = self.server_port;
+        let bind_address = self.bind_address;
 
         self.net_loop_thread = Some(
             //this panics with normal thread creation anyway
             #[allow(clippy::unwrap_used)]
             std::thread::Builder::new()
                 .name("Server networking".to_owned())
-                .spawn(move || Self::net_receive_loop(&event_sender, &packet_receiver, &is_running, server_port))
+                .spawn(move || Self::net_receive_loop(&event_sender, &packet_receiver, &is_running, server_port, bind_address))
                 .unwrap(),
         );
     }
 
     #[allow(clippy::expect_used)]
     #[allow(clippy::unwrap_in_result)]
-    fn net_receive_loop(event_sender: &Sender<Event>, packet_receiver: &Receiver<(Vec<u8>, Connection)>, is_running: &Arc<AtomicBool>, server_port: u16) -> Result<()> {
+    fn net_receive_loop(event_sender: &Sender<Event>, packet_receiver: &Receiver<(Vec<u8>, Connection)>, is_running: &Arc<AtomicBool>, server_port: u16, bind_address: BindAddress) -> Result<()> {
         let (handler, listener) = node::split::<()>();
 
-        let listen_addr = format!("127.0.0.1:{server_port}");
-        handler.network().listen(Transport::FramedTcp, listen_addr)?;
+        let listen_addr = format!("{}:{server_port}", bind_address.as_ip());
+        handler.network().listen(Transport::FramedTcp, &listen_addr)?;
+        print_to_console(&format!("listening on {listen_addr}"), 0);
+
+        if bind_address == BindAddress::AllInterfaces {
+            print_to_console(
+                "this server is reachable from the network and has no authentication, so anyone who can reach this port can join and change the world",
+                1,
+            );
+        }
 
         handler.signals().send(());
 


### PR DESCRIPTION
> ⚠️ **This intentionally opens a network port.** Please read the authentication note below before merging.

## The problem

```rust
let listen_addr = format!("127.0.0.1:{server_port}");
```

The server only ever accepted connections from the same machine — while the client ships a complete "add server by IP" flow (`add_server_menu.rs`, `multiplayer_selector.rs`) that parses an arbitrary `host:port`. The multiplayer UI advertised something the server couldn't do.

## Why this isn't a one-line change

Binding `0.0.0.0` unconditionally would be **wrong**, because singleplayer is also a `Server` — `client/game/private_world.rs` starts one on `SINGLEPLAYER_PORT`. That would have put every singleplayer world on the local network.

So the address is explicit per server. A `BindAddress` enum threaded through `Server::new` and `ServerNetworking::new`:

| call site | binds |
|---|---|
| `private_world.rs` (singleplayer) | `Loopback` — stays local |
| `main.rs` `server_main` (dedicated) | `AllInterfaces` — reachable |

## Authentication

The server now logs what it's listening on, and **warns when that's public**, because the game protocol has no authentication of any kind:

```
[INFO] listening on 0.0.0.0:49153
[WARNING] this server is reachable from the network and has no authentication,
          so anyone who can reach this port can join and change the world
```

Anyone who can reach the port can join and modify the world. That's worth knowing before port-forwarding it, and it's why this pairs naturally with #168 — until that lands, they can also crash the server with a chat message.

## Verification

Ran a real dedicated server and checked the actual socket, not just the log line:

```
[INFO] listening on 0.0.0.0:49153
$ lsof -nP -iTCP -sTCP:LISTEN -p <pid>
terralist  41947  jakob  9u  IPv4  ...  TCP *:49153 (LISTEN)
```

`cargo test` 39/39, clippy and fmt clean.

## Follow-up

Making the bind address configurable from the command line (`-- server bind=...`) would be reasonable. This keeps the change to the two cases that exist today rather than inventing config surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)